### PR TITLE
Added example for binding multiple attributes to a slot

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -268,6 +268,16 @@ To make `item` available to the slot content provided by the parent, we can add 
 </ul>
 ```
 
+You can bind as many attributes to the `slot` as you need:
+
+```html
+<ul>
+  <li v-for="( item, index ) in items">
+    <slot :item="item" :index="index" :another-attribute="anotherAttribute"></slot>
+  </li>
+</ul>
+```
+
 Attributes bound to a `<slot>` element are called **slot props**. Now, in the parent scope, we can use `v-slot` with a value to define a name for the slot props we've been provided:
 
 ```html


### PR DESCRIPTION
To me, reading the docs at first, didn't make it very clear how to bind multiple attributes to one slot.

I've added an example how to do it.